### PR TITLE
Fix alpine snappy

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -35,6 +35,7 @@ FROM openjdk:%%VARIANT%%
 LABEL maintainer="Monogramm Maintainers <opensource at monogramm dot io>"
 
 ENV CLOJURE_VERSION=1.10.1.458 \
+    GLIBC_VERSION=2.29-r0 \
     LANG=en_US.UTF-8 \
     LC_ALL=C.UTF-8
 
@@ -54,7 +55,10 @@ RUN set -ex; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \
     rm -rf clojure-linux-install.sh; \
-    clojure -h
+    clojure -h; \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk; \
+    apk add --no-cache --allow-untrusted glibc-${GLIBC_VERSION}.apk; \
+    rm glibc-${GLIBC_VERSION}.apk
 
 # Add uxbox as provided by builder and create directories
 COPY --from=0 /home/uxbox/backend/dist/uxbox-backend.tar.gz /usr/src/uxbox-backend.tar.gz

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -49,7 +49,7 @@ RUN set -ex; \
         libwebp \
         rsync \
     ; \
-	rm -rf /var/cache/apk/*; \
+    rm -rf /var/cache/apk/*; \
     curl -L -o clojure-linux-install.sh "https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \

--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -46,7 +46,6 @@ RUN set -ex; \
         bash \
         curl \
         imagemagick \
-        libc6-compat \
         libwebp \
         rsync \
     ; \

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -47,7 +47,7 @@ RUN set -ex; \
         rsync \
         webp \
     ; \
-	rm -rf /var/lib/apt/lists/*; \
+    rm -rf /var/lib/apt/lists/*; \
     curl -L -o clojure-linux-install.sh "https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \

--- a/images/master/11-jdk-slim/Dockerfile
+++ b/images/master/11-jdk-slim/Dockerfile
@@ -47,7 +47,7 @@ RUN set -ex; \
         rsync \
         webp \
     ; \
-	rm -rf /var/lib/apt/lists/*; \
+    rm -rf /var/lib/apt/lists/*; \
     curl -L -o clojure-linux-install.sh "https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \

--- a/images/master/11-jdk/Dockerfile
+++ b/images/master/11-jdk/Dockerfile
@@ -47,7 +47,7 @@ RUN set -ex; \
         rsync \
         webp \
     ; \
-	rm -rf /var/lib/apt/lists/*; \
+    rm -rf /var/lib/apt/lists/*; \
     curl -L -o clojure-linux-install.sh "https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \

--- a/images/master/13-jdk-alpine/Dockerfile
+++ b/images/master/13-jdk-alpine/Dockerfile
@@ -35,6 +35,7 @@ FROM openjdk:13-jdk-alpine
 LABEL maintainer="Monogramm Maintainers <opensource at monogramm dot io>"
 
 ENV CLOJURE_VERSION=1.10.1.458 \
+    GLIBC_VERSION=2.29-r0 \
     LANG=en_US.UTF-8 \
     LC_ALL=C.UTF-8
 
@@ -54,7 +55,10 @@ RUN set -ex; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \
     rm -rf clojure-linux-install.sh; \
-    clojure -h
+    clojure -h; \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk; \
+    apk add --no-cache --allow-untrusted glibc-${GLIBC_VERSION}.apk; \
+    rm glibc-${GLIBC_VERSION}.apk
 
 # Add uxbox as provided by builder and create directories
 COPY --from=0 /home/uxbox/backend/dist/uxbox-backend.tar.gz /usr/src/uxbox-backend.tar.gz

--- a/images/master/13-jdk-alpine/Dockerfile
+++ b/images/master/13-jdk-alpine/Dockerfile
@@ -49,7 +49,7 @@ RUN set -ex; \
         libwebp \
         rsync \
     ; \
-	rm -rf /var/cache/apk/*; \
+    rm -rf /var/cache/apk/*; \
     curl -L -o clojure-linux-install.sh "https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \

--- a/images/master/13-jdk-alpine/Dockerfile
+++ b/images/master/13-jdk-alpine/Dockerfile
@@ -46,7 +46,6 @@ RUN set -ex; \
         bash \
         curl \
         imagemagick \
-        libc6-compat \
         libwebp \
         rsync \
     ; \

--- a/images/master/8-jre-alpine/Dockerfile
+++ b/images/master/8-jre-alpine/Dockerfile
@@ -35,6 +35,7 @@ FROM openjdk:8-jre-alpine
 LABEL maintainer="Monogramm Maintainers <opensource at monogramm dot io>"
 
 ENV CLOJURE_VERSION=1.10.1.458 \
+    GLIBC_VERSION=2.29-r0 \
     LANG=en_US.UTF-8 \
     LC_ALL=C.UTF-8
 
@@ -54,7 +55,10 @@ RUN set -ex; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \
     rm -rf clojure-linux-install.sh; \
-    clojure -h
+    clojure -h; \
+    wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk; \
+    apk add --no-cache --allow-untrusted glibc-${GLIBC_VERSION}.apk; \
+    rm glibc-${GLIBC_VERSION}.apk
 
 # Add uxbox as provided by builder and create directories
 COPY --from=0 /home/uxbox/backend/dist/uxbox-backend.tar.gz /usr/src/uxbox-backend.tar.gz

--- a/images/master/8-jre-alpine/Dockerfile
+++ b/images/master/8-jre-alpine/Dockerfile
@@ -49,7 +49,7 @@ RUN set -ex; \
         libwebp \
         rsync \
     ; \
-	rm -rf /var/cache/apk/*; \
+    rm -rf /var/cache/apk/*; \
     curl -L -o clojure-linux-install.sh "https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \

--- a/images/master/8-jre-alpine/Dockerfile
+++ b/images/master/8-jre-alpine/Dockerfile
@@ -46,7 +46,6 @@ RUN set -ex; \
         bash \
         curl \
         imagemagick \
-        libc6-compat \
         libwebp \
         rsync \
     ; \

--- a/images/master/8-jre-slim/Dockerfile
+++ b/images/master/8-jre-slim/Dockerfile
@@ -47,7 +47,7 @@ RUN set -ex; \
         rsync \
         webp \
     ; \
-	rm -rf /var/lib/apt/lists/*; \
+    rm -rf /var/lib/apt/lists/*; \
     curl -L -o clojure-linux-install.sh "https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \

--- a/images/master/8-jre/Dockerfile
+++ b/images/master/8-jre/Dockerfile
@@ -47,7 +47,7 @@ RUN set -ex; \
         rsync \
         webp \
     ; \
-	rm -rf /var/lib/apt/lists/*; \
+    rm -rf /var/lib/apt/lists/*; \
     curl -L -o clojure-linux-install.sh "https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh"; \
     chmod +x clojure-linux-install.sh; \
     ./clojure-linux-install.sh; \


### PR DESCRIPTION
:construction: Fix issue on login with alpine backend:
```
java.lang.UnsatisfiedLinkError: /tmp/snappy-1.1.2-09322b02-ab95-4e7f-8497-c6787f1f4a60-libsnappyjava.so: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /tmp/snappy-1.1.2-09322b02-ab95-4e7f-8497-c6787f1f4a60-libsnappyjava.so)
  at java.lang.ClassLoader$NativeLibrary.load(Native Method)
  at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1941)
  at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1824)
  at java.lang.Runtime.load0(Runtime.java:809)
  at java.lang.System.load(System.java:1086)
  at org.xerial.snappy.SnappyLoader.loadNativeLibrary(SnappyLoader.java:174)
  at org.xerial.snappy.SnappyLoader.load(SnappyLoader.java:152)
  at org.xerial.snappy.Snappy.<clinit>(Snappy.java:47)
  at java.lang.Class.forName0(Native Method)
  at java.lang.Class.forName(Class.java:348)
  at clojure.lang.RT.classForName(RT.java:2207)
  at clojure.lang.RT.classForName(RT.java:2216)
  at uxbox.util.snappy$compress.invokeStatic(snappy.clj:22)
  at uxbox.util.snappy$compress.invoke(snappy.clj:18)
  at uxbox.util.blob$encode.invokeStatic(blob.clj:15)
  at uxbox.util.blob$encode.invoke(blob.clj:12)
  at uxbox.services.users$register_user.invokeStatic(users.clj:169)
  at uxbox.services.users$register_user.invoke(users.clj:164)
  at clojure.lang.AFn.applyToHelper(AFn.java:156)
  at clojure.lang.AFn.applyTo(AFn.java:144)
  at clojure.core$apply.invokeStatic(core.clj:667)
  at clojure.core$apply.invoke(core.clj:660)
  at suricatta.transaction$apply_atomic.invokeStatic(transaction.clj:66)
  at suricatta.transaction$apply_atomic.doInvoke(transaction.clj:56)
  at clojure.lang.RestFn.applyTo(RestFn.java:142)
  at clojure.core$apply.invokeStatic(core.clj:665)
  at clojure.core$apply.invoke(core.clj:660)
  at suricatta.core$apply_atomic.invokeStatic(core.clj:117)
  at suricatta.core$apply_atomic.doInvoke(core.clj:114)
  at clojure.lang.RestFn.invoke(RestFn.java:436)
  at uxbox.services.users$eval25040$fn__25041.invoke(users.clj:192)
  at clojure.lang.MultiFn.invoke(MultiFn.java:229)
  at uxbox.services$handle_novelty.invokeStatic(services.clj:38)
  at uxbox.services$handle_novelty.invoke(services.clj:36)
  at clojure.core$partial$fn__5824.invoke(core.clj:2623)
  at executors.core$eval5512$fn$reify__5516.get(core.clj:97)
  at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
  at java.lang.Thread.run(Thread.java:748)
 [uxbox-scheduler_Worker-1] INFO uxbox.scheduled-jobs.emails - task-send-immediate-emails...
 [uxbox-scheduler_Worker-1] INFO uxbox.scheduled-jobs.emails - task-send-immediate-emails...
 [uxbox-scheduler_Worker-1] INFO uxbox.scheduled-jobs.emails - task-send-immediate-emails...
 [uxbox-scheduler_Worker-1] INFO uxbox.scheduled-jobs.emails - task-send-immediate-emails...
 [uxbox-scheduler_Worker-1] INFO uxbox.scheduled-jobs.emails - task-send-failed-emails...
 java.lang.NoClassDefFoundError: Could not initialize class org.xerial.snappy.Snappy
  at java.lang.Class.forName0(Native Method)
  at java.lang.Class.forName(Class.java:348)
  at clojure.lang.RT.classForName(RT.java:2207)
  at clojure.lang.RT.classForName(RT.java:2216)
  at uxbox.util.snappy$compress.invokeStatic(snappy.clj:22)
  at uxbox.util.snappy$compress.invoke(snappy.clj:18)
  at uxbox.util.blob$encode.invokeStatic(blob.clj:15)
  at uxbox.util.blob$encode.invoke(blob.clj:12)
  at uxbox.services.users$register_user.invokeStatic(users.clj:169)
  at uxbox.services.users$register_user.invoke(users.clj:164)
  at clojure.lang.AFn.applyToHelper(AFn.java:156)
  at clojure.lang.AFn.applyTo(AFn.java:144)
  at clojure.core$apply.invokeStatic(core.clj:667)
  at clojure.core$apply.invoke(core.clj:660)
  at suricatta.transaction$apply_atomic.invokeStatic(transaction.clj:66)
  at suricatta.transaction$apply_atomic.doInvoke(transaction.clj:56)
  at clojure.lang.RestFn.applyTo(RestFn.java:142)
  at clojure.core$apply.invokeStatic(core.clj:665)
  at clojure.core$apply.invoke(core.clj:660)
  at suricatta.core$apply_atomic.invokeStatic(core.clj:117)
  at suricatta.core$apply_atomic.doInvoke(core.clj:114)
  at clojure.lang.RestFn.invoke(RestFn.java:436)
  at uxbox.services.users$eval25040$fn__25041.invoke(users.clj:192)
  at clojure.lang.MultiFn.invoke(MultiFn.java:229)
  at uxbox.services$handle_novelty.invokeStatic(services.clj:38)
  at uxbox.services$handle_novelty.invoke(services.clj:36)
  at clojure.core$partial$fn__5824.invoke(core.clj:2623)
  at executors.core$eval5512$fn$reify__5516.get(core.clj:97)
  at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1590)
  at java.lang.Thread.run(Thread.java:748)

```